### PR TITLE
🩹 Prevent i18n errors

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -29,8 +29,15 @@ export function formatMessage(id: string, locale: LocaleString | 'en', values: R
 	// At the end of the loop, it must be a string. 
 	for (const key of path) {
 		template = template[key];
-		if (!template)
-			throw new Error(`Unknown i18n id: '${id}'`);
+		if (!template) {
+			// If it fails in english there is nothing to do but throw an error.
+			// If it fails in another language we can try to return the english version instead.
+			if (locale === 'en')
+				throw new Error(`Unknown i18n id: '${id}'`);
+			else
+				return formatMessage(id, 'en', values);
+
+		}
 	}
 	if (typeof template !== 'string')
 		throw new Error(`Incorrect i18n id: '${id}', this seems to be a locale scope and not a locale string.`);

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -72,9 +72,15 @@ export class LocalizedSlashCommandBuilder extends SlashCommandBuilder {
 		for (const language of AvailableLanguages) {
 			// English is the default language, this loop is only for the other languages.
 			if (language === 'en') continue;
-			const locale = require(`../../i18n/commands/${language}.json`)[name];
-			this.setNameLocalization(language, locale.name)
-				.setDescriptionLocalization(language, locale.description);
+			try {
+				const locale = require(`../../i18n/commands/${language}.json`)[name];
+				this.setNameLocalization(language, locale.name)
+					.setDescriptionLocalization(language, locale.description);
+			} catch (_) {
+				// Shit happened, we fallback to english.
+				this.setNameLocalization(language, en.name)
+					.setDescriptionLocalization(language, en.description);
+			}
 		}
 	}
 
@@ -89,9 +95,15 @@ export class LocalizedSlashCommandBuilder extends SlashCommandBuilder {
 		for (const language of AvailableLanguages) {
 			// English is the default language, this loop is only for the other languages.
 			if (language === 'en') continue;
-			const locale = require(`../../i18n/commands/${language}.json`)[this.name].options[name];
-			builder.setNameLocalization(language, locale.label)
-				.setDescriptionLocalization(language, locale.description);
+			try {
+				const locale = require(`../../i18n/commands/${language}.json`)[this.name].options[name];
+				builder.setNameLocalization(language, locale.label)
+					.setDescriptionLocalization(language, locale.description);
+			} catch (_) {
+				// Shit happened, we fallback to english.
+				builder.setNameLocalization(language, en.label)
+					.setNameLocalization(language, en.description);
+			}
 		}
 		switch (builder.type) {
 			case ApplicationCommandOptionType.Attachment:


### PR DESCRIPTION
In case something fails when trying to set a slash command localized string or when trying to format a 
message in a non-english locale, we retry the same task using english locale. English is very unlikely to 
fail so it add a layer of safety. Also, instead of throwing an error when a locale string can't be found, we just return the locale id instead. The error will still be very clear but it won't make the bot fail.

This is helpful especially during development as it allows to implement new slash commands without worrying about translating the strings in every available language.


