### PR TITLE
Allow members to join the game themself

### DIFF
--- a/i18n/commands/en.json
+++ b/i18n/commands/en.json
@@ -69,5 +69,13 @@
 				"description": "The page to look up"
 			}
 		}
+	},
+	"join": {
+		"name": "join",
+		"description": "Gives you the mosus player role"
+	},
+	"leave": {
+		"name": "leave",
+		"description": "Takes the mosus player role away from you"
 	}
 }

--- a/i18n/commands/en.json
+++ b/i18n/commands/en.json
@@ -77,5 +77,9 @@
 	"leave": {
 		"name": "leave",
 		"description": "Takes the mosus player role away from you"
+	},
+	"close-votes": {
+		"name": "close-votes",
+		"description": "Closes the vote phase prematurely"
 	}
 }

--- a/i18n/commands/fr.json
+++ b/i18n/commands/fr.json
@@ -69,5 +69,13 @@
 				"description": "La page à consulter"
 			}
 		}
+	},
+	"join": {
+		"name": "jouer",
+		"description": "Vous donne le rôle de joueur mosus"
+	},
+	"leave": {
+		"name": "quitter",
+		"description": "Vous retire le rôle de joueur mosus"
 	}
 }

--- a/i18n/commands/fr.json
+++ b/i18n/commands/fr.json
@@ -77,5 +77,9 @@
 	"leave": {
 		"name": "quitter",
 		"description": "Vous retire le rôle de joueur mosus"
+	},
+	"close-votes": {
+		"name": "fermer-votes",
+		"description": "Met prématurément fin à la phase de vote"
 	}
 }

--- a/i18n/commands/ko.json
+++ b/i18n/commands/ko.json
@@ -76,5 +76,9 @@
 		"leave": {
 			"name": "떠나기",
 			"description": "mosus을 놀이를 그만두기"
+		},
+		"close-votes": {
+			"name": "투표-끝",
+			"description": "투표 단계를 끝나기"
 		}
 }

--- a/i18n/commands/ko.json
+++ b/i18n/commands/ko.json
@@ -68,5 +68,13 @@
 					"description": "리스트의 무슨 페이지"
 				}
 			}
+		},
+		"join": {
+			"name": "놀기",
+			"description": "mosus 참가자 역할을 받기"
+		},
+		"leave": {
+			"name": "떠나기",
+			"description": "mosus을 놀이를 그만두기"
 		}
 }

--- a/i18n/general/en.json
+++ b/i18n/general/en.json
@@ -40,7 +40,13 @@
 		"noScores": "No one has ever earned any point in this server so far.",
 		"unknownGame": "This game was not found.",
 		"forbiddenGame": "You can't access data about this game.",
-		"gameNotFinished": "This game has not finished yet."
+		"gameNotFinished": "This game has not finished yet.",
+		"alreadyHasRole": "You're already a player!",
+		"couldntGiveRole": "An error occured when trying to give you the mosus player role.",
+		"addedRole": "You now have the {role} role! Don't be too sus...",
+		"doesntHaveRole": "You are not a mosus player.",
+		"couldntRemoveRole": "An error occured when trying to remove the mosus player role from you.",
+		"removedRole": "You are no longer a mosus player!"
 	},
 	"scoreboard": {
 		"title": "Scoreboard",

--- a/i18n/general/fr.json
+++ b/i18n/general/fr.json
@@ -41,7 +41,13 @@
 		"noScores": "Personne n'a encore marqué de point dans ce serveur.",
 		"unknownGame": "Partie non trouvée.",
 		"forbiddenGame": "Vous n'avez pas accès aux informations de cette partie.",
-		"gameNotFinished": "Cette partie n'est pas encore terminée."
+		"gameNotFinished": "Cette partie n'est pas encore terminée.",
+		"alreadyHasRole": "Vous êtes déjà un joueur de mosus !",
+		"couldntGiveRole": "Une erreur est survenue et le rôle n'a pas pu vous être donné",
+		"addedRole": "Vous avez désormais le rôle {role} ! Ne soyez pas trop sus...",
+		"doesntHaveRole": "Vous n'êtes pas un joueur de mosus.",
+		"couldntRemoveRole": "Une erreur est survenue et le rôle n'a pas pu vous être retiré",
+		"removedRole": "Vous n'êtes plus un joueur de mosus"
 	},
 	"scoreboard": {
 		"title": "Tableau des scores",

--- a/i18n/general/ko.json
+++ b/i18n/general/ko.json
@@ -40,7 +40,13 @@
 		"noScores": "아직 아무도 점수를 받았지 않습니다.",
 		"unknownGame": "그 게임을 찾을 수 없습니다",
 		"forbiddenGame": "그 게임에 대한 정보를 볼 수 없습니다.",
-		"gameNotFinished": "그 게임이 끝나지 않습니다."
+		"gameNotFinished": "그 게임이 끝나지 않습니다.",
+		"alreadyHasRole": "본인은 mosus 역할이 있습니다.",
+		"couldntGiveRole": "mosus 역할을 줄 수 없습니다.",
+		"addedRole": "본인은 {mosus} 역할을 받았습니다!",
+		"doesntHaveRole": "본인은 mosus 역할이 없습니다.",
+		"couldntRemoveRole": "본인에서 mosus 역할을 치울 수 없습니다.",
+		"removedRole": "본인은 더 이상 mosus 역할이 없습니다."
 	},
 	"scoreboard": {
 		"title": "스코어보드",

--- a/src/commands/close-votes.ts
+++ b/src/commands/close-votes.ts
@@ -1,0 +1,38 @@
+import { CacheType, CommandInteraction, Guild, TextChannel } from 'discord.js';
+import Client from '../base/Client';
+import Command from '../base/Command';
+import endGame from '../lib/endGame';
+import { formatMessage, LocalizedSlashCommandBuilder } from '../lib/i18n';
+import SavedGuild from '../types/SavedGuild';
+const data = new LocalizedSlashCommandBuilder('close-votes');
+export default class extends Command {
+	constructor(client: Client) {
+		super(client, 'close-votes', true, data.toJSON());
+	}
+
+	public async execute(interaction: CommandInteraction<CacheType>, guild: Guild, save: SavedGuild): Promise<void> {
+		const game = await this.client.db.getGame(save.game || -1);
+		if (!game)
+			return void interaction.reply({
+				content: formatMessage('ephemeral.notInGame', interaction.locale),
+				ephemeral: true
+			});
+		if (game.status !== 'voting')
+			return void interaction.reply({
+				content: formatMessage('ephemeral.notInVote', interaction.locale),
+				ephemeral: true
+			});
+		if (game.host !== interaction.user.id)
+			return void interaction.reply({
+				content: formatMessage('ephemeral.notHost', interaction.locale),
+				ephemeral: true
+			});
+		this.client.db.setGameStatus(game.id, 'ended');
+		const votes = await this.client.db.getVotes(game.id);
+		endGame(this.client, save, game, votes, interaction.channel! as TextChannel);
+		interaction.reply({
+			ephemeral: true,
+			content: '👍' // c'est bon j'ai trop la flemme de faire encore un string i18n
+		});
+	}
+}

--- a/src/commands/join.ts
+++ b/src/commands/join.ts
@@ -1,0 +1,26 @@
+import { ChatInputCommandInteraction, Guild, SlashCommandRoleOption, GuildMember } from 'discord.js';
+import Client from '../base/Client';
+import Command from '../base/Command';
+import { formatMessage, LocalizedSlashCommandBuilder } from '../lib/i18n';
+import SavedGuild from '../types/SavedGuild';
+
+const data = new LocalizedSlashCommandBuilder('join');
+export default class extends Command {
+	constructor(client: Client) {
+		super(client, 'join', true, data.toJSON());
+	}
+public async execute(interaction: ChatInputCommandInteraction, guild: Guild, save: SavedGuild): Promise<void> {
+		const role = save.role!;
+		const member = interaction.member! as GuildMember;
+		await member.fetch();
+		if (member.roles.cache.has(role))
+			return void interaction.reply({ content: formatMessage('ephemeral.alreadyHasRole', interaction.locale), ephemeral: true });
+		try {
+			await member.roles.add(role);
+		} catch (_) {
+			return void interaction.reply({ content: formatMessage('ephemeral.couldntGiveRole', interaction.locale), ephemeral: true });
+		}
+		interaction.reply({ content: formatMessage('ephemeral.addedRole', interaction.locale, {role: `<@&${role}>`}), ephemeral: true});
+	}
+}
+

--- a/src/commands/leave.ts
+++ b/src/commands/leave.ts
@@ -1,0 +1,26 @@
+import { ChatInputCommandInteraction, Guild, SlashCommandRoleOption, GuildMember } from 'discord.js';
+import Client from '../base/Client';
+import Command from '../base/Command';
+import { formatMessage, LocalizedSlashCommandBuilder } from '../lib/i18n';
+import SavedGuild from '../types/SavedGuild';
+
+const data = new LocalizedSlashCommandBuilder('leave');
+export default class extends Command {
+	constructor(client: Client) {
+		super(client, 'leave', true, data.toJSON());
+	}
+public async execute(interaction: ChatInputCommandInteraction, guild: Guild, save: SavedGuild): Promise<void> {
+		const role = save.role!;
+		const member = interaction.member! as GuildMember;
+		await member.fetch();
+		if (!member.roles.cache.has(role))
+			return void interaction.reply({ content: formatMessage('ephemeral.doesntHaveRole', interaction.locale), ephemeral: true });
+		try {
+			await member.roles.remove(role);
+		} catch (_) {
+			return void interaction.reply({ content: formatMessage('ephemeral.couldntRemoveRole', interaction.locale), ephemeral: true });
+		}
+		interaction.reply({ content: formatMessage('ephemeral.removedRole', interaction.locale), ephemeral: true});
+	}
+}
+

--- a/src/commands/set-role.ts
+++ b/src/commands/set-role.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction, Guild, SlashCommandRoleOption } from 'discord.js';
+import { ChatInputCommandInteraction, Guild, SlashCommandRoleOption, Role } from 'discord.js';
 import Client from '../base/Client';
 import Command from '../base/Command';
 import { formatMessage, LocalizedSlashCommandBuilder } from '../lib/i18n';
@@ -18,8 +18,10 @@ export default class extends Command {
 	public execute(interaction: ChatInputCommandInteraction, guild: Guild, save: SavedGuild): void {
 		// Only members with the `Manage Messages` permission can change the mosus settings in a guild.
 		if (!interaction.memberPermissions || !interaction.memberPermissions.has('ManageMessages'))
-			return void interaction.reply({ content: formatMessage('ephemeral.missingPermission', 'fr'), ephemeral: true });
-		const role = interaction.options.getRole('role', true);
+			return void interaction.reply({ content: formatMessage('ephemeral.missingPermission', interaction.locale), ephemeral: true });
+		const role = interaction.options.getRole('role', true) as Role;
+		if (!role.editable)
+			return void interaction.reply({ content: formatMessage('ephemeral.cantEditRole', interaction.locale), ephemeral: true });
 		this.client.db.setGuildRole(guild.id, role.id);
 		interaction.reply({
 			content: formatMessage('ephemeral.roleSet', interaction.locale, { role }),


### PR DESCRIPTION
Adds the `/join` and `/leave` commands for the members to choose whether they want to play mosus, without the need to have the permission to manage roles. This implies a modification in `/set-role`, which makes sure the set role is manageable by the bot.
With the volatility allowed by these new commands, a `/close-votes` is also added to make sure a game can be stopped.